### PR TITLE
fix: render homepage icons

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,8 @@ hide:
 
 Welcome to my notes page. I love to learn and share my knowledge. Here you'll find notes, cheatsheets, and code snippets for various topics. These are documented mostly for my own reference.
 
-<center>
+<div align="center" markdown>
 
-[Linux :simple-linux:](linux/curl.md){ .md-button } [K8S :simple-kubernetes:](k8s/intro.md){ .md-button } [AWS :fontawesome-brands-aws:](AWS/cli.md){ .md-button } [Today I Learned :bookmark:](til/index.md){ .md-button } [Snippets :material-code-array:](snippets.md){ .md-button }
-</center>
+[Linux :simple-linux:](linux/curl.md){ .md-button } [K8S :simple-kubernetes:](k8s/intro.md){ .md-button } [AWS :fontawesome-brands-aws:](aws/cli.md){ .md-button } [Today I Learned :bookmark:](til/index.md){ .md-button } [Snippets :material-code-array:](snippets.md){ .md-button }
+</div>
+


### PR DESCRIPTION
## Summary
- ensure homepage icons render by parsing markdown within center-aligned div
- correct AWS docs link path to avoid broken link warning

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_b_68c40ffd7120832382107e6303f973d6